### PR TITLE
Support truecolor and background transparency

### DIFF
--- a/colors/primary.vim
+++ b/colors/primary.vim
@@ -25,8 +25,9 @@ if exists('syntax_on')
 endif
 let g:colors_name = 'primary'
 let s:disable_italic = get(g:,'colorscheme_primary_disable_italic', 0)
+let s:enable_transparent_bg = get(g:,'colorscheme_primary_enable_transparent_bg', 0)
 
-if (has('gui_running'))  "Graphical Vim
+if has('gui_running') || has('termguicolors')  "Graphical Vim
   "Set color palette with RGB colors
   let s:RED    = '#EA4335'
   let s:GREEN  = '#34A853'
@@ -93,89 +94,95 @@ endif
 
 
 " Colors for Syntax Highlighting.
-exe 'hi String       '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:RED  .' '.s:M.'='.s:I
-exe 'hi Character    '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:RED  .' '.s:M.'='.s:I
-exe 'hi Conditional  '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:RED  .' '.s:M.'=bold'
-exe 'hi Label        '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:RED  .' '.s:M.'=bold'
-exe 'hi Repeat       '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:RED  .' '.s:M.'=bold'
-exe 'hi Statement    '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:RED  .' '.s:M.'=bold'
-exe 'hi Keyword      '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:RED  .' '.s:M.'=bold'
-exe 'hi Exception    '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:RED  .' '.s:M.'=bold'
+if (s:enable_transparent_bg == 1)
+  exe 'hi Normal       '.s:M.'bg=NONE         '.s:M.'fg='.s:BLUE .' '.s:M.'=none'
+  exe 'hi NonText      '.s:M.'bg=NONE         '.s:M.'fg='.s:GREY1.' '.s:M.'=bold'
+else
+  exe 'hi Normal       '.s:M.'bg='.s:BG    .' '.s:M.'fg='.s:BLUE .' '.s:M.'=none'
+  exe 'hi NonText      '.s:M.'bg='.s:BG    .' '.s:M.'fg='.s:GREY1.' '.s:M.'=bold'
+endif
 
-exe 'hi Normal       '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:BLUE .' '.s:M.'=none'
-exe 'hi Identifier   '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:BLUE .' '.s:M.'=bold'
-exe 'hi Function     '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:BLUE .' '.s:M.'=bold'
+exe 'hi String         '.s:M.'fg='.s:RED   .' '.s:M.'='.s:I
+exe 'hi Character      '.s:M.'fg='.s:RED   .' '.s:M.'='.s:I
+exe 'hi Conditional    '.s:M.'fg='.s:RED   .' '.s:M.'=bold'
+exe 'hi Label          '.s:M.'fg='.s:RED   .' '.s:M.'=bold'
+exe 'hi Repeat         '.s:M.'fg='.s:RED   .' '.s:M.'=bold'
+exe 'hi Statement      '.s:M.'fg='.s:RED   .' '.s:M.'=bold'
+exe 'hi Keyword        '.s:M.'fg='.s:RED   .' '.s:M.'=bold'
+exe 'hi Exception      '.s:M.'fg='.s:RED   .' '.s:M.'=bold'
 
-exe 'hi Comment      '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREEN.' '.s:M.'=none'
-exe 'hi Typedef      '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREEN.' '.s:M.'='.s:I
-exe 'hi PreProc      '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREEN.' '.s:M.'=bold'
-exe 'hi Include      '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREEN.' '.s:M.'=bold'
-exe 'hi Define       '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREEN.' '.s:M.'=bold'
-exe 'hi Macro        '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREEN.' '.s:M.'=bold'
-exe 'hi Precondit    '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREEN.' '.s:M.'=bold'
-exe 'hi SpecialComment '.s:M.'bg='.s:BG.' '.s:M.'fg='.s:GREEN.' '.s:M.'=bold'
+exe 'hi Identifier     '.s:M.'fg='.s:BLUE  .' '.s:M.'=bold'
+exe 'hi Function       '.s:M.'fg='.s:BLUE  .' '.s:M.'=bold'
 
-exe 'hi Special      '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY0.' '.s:M.'=none'
-exe 'hi Delimiter    '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY0.' '.s:M.'=none'
-exe 'hi Debug        '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY0.' '.s:M.'=none'
-exe 'hi SpecialChar  '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY0.' '.s:M.'=bold'
-exe 'hi Title        '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY0.' '.s:M.'=bold'
+exe 'hi Comment        '.s:M.'fg='.s:GREEN .' '.s:M.'=none'
+exe 'hi Typedef        '.s:M.'fg='.s:GREEN .' '.s:M.'='.s:I
+exe 'hi PreProc        '.s:M.'fg='.s:GREEN .' '.s:M.'=bold'
+exe 'hi Include        '.s:M.'fg='.s:GREEN .' '.s:M.'=bold'
+exe 'hi Define         '.s:M.'fg='.s:GREEN .' '.s:M.'=bold'
+exe 'hi Macro          '.s:M.'fg='.s:GREEN .' '.s:M.'=bold'
+exe 'hi Precondit      '.s:M.'fg='.s:GREEN .' '.s:M.'=bold'
+exe 'hi SpecialComment '.s:M.'fg='.s:GREEN .' '.s:M.'=bold'
 
-exe 'hi Constant     '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY1.' '.s:M.'=none'
-exe 'hi Boolean      '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY1.' '.s:M.'=none'
-exe 'hi Number       '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY1.' '.s:M.'=none'
-exe 'hi Float        '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY1.' '.s:M.'=none'
-exe 'hi Operator     '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY1.' '.s:M.'=bold'
-exe 'hi Tag          '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY1.' '.s:M.'=bold'
-exe 'hi Ignore       '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY1.' '.s:M.'=none'
-exe 'hi Underlined   '.s:M.'bg='.s:BG  .' '.s:M.'fg='.s:GREY1 .' '.s:M.'=underline'
+exe 'hi Special        '.s:M.'fg='.s:GREY0 .' '.s:M.'=none'
+exe 'hi Delimiter      '.s:M.'fg='.s:GREY0 .' '.s:M.'=none'
+exe 'hi Debug          '.s:M.'fg='.s:GREY0 .' '.s:M.'=none'
+exe 'hi SpecialChar    '.s:M.'fg='.s:GREY0 .' '.s:M.'=bold'
+exe 'hi Title          '.s:M.'fg='.s:GREY0 .' '.s:M.'=bold'
 
-exe 'hi MatchParen   '.s:M.'bg='.s:RED .' '.s:M.'fg='.s:BG   .' '.s:M.'=none'
-exe 'hi Error        '.s:M.'bg='.s:RED .' '.s:M.'fg='.s:BG   .' '.s:M.'=none'
+exe 'hi Constant       '.s:M.'fg='.s:GREY1 .' '.s:M.'=none'
+exe 'hi Boolean        '.s:M.'fg='.s:GREY1 .' '.s:M.'=none'
+exe 'hi Number         '.s:M.'fg='.s:GREY1 .' '.s:M.'=none'
+exe 'hi Float          '.s:M.'fg='.s:GREY1 .' '.s:M.'=none'
+exe 'hi Operator       '.s:M.'fg='.s:GREY1 .' '.s:M.'=bold'
+exe 'hi Tag            '.s:M.'fg='.s:GREY1 .' '.s:M.'=bold'
+exe 'hi Ignore         '.s:M.'fg='.s:GREY1 .' '.s:M.'=none'
+exe 'hi Underlined     '.s:M.'fg='.s:GREY1 .' '.s:M.'=underline'
 
-exe 'hi Type         '.s:M.'bg='.s:BG .' '.s:M.'fg='.s:YELLOW.' '.s:M.'=bold'
-exe 'hi StorageClass '.s:M.'bg='.s:BG .' '.s:M.'fg='.s:YELLOW.' '.s:M.'=bold'
-exe 'hi Structure    '.s:M.'bg='.s:BG .' '.s:M.'fg='.s:YELLOW.' '.s:M.'=bold'
-exe 'hi Todo         '.s:M.'bg='.s:YELLOW.' '.s:M.'fg='.s:BG .' '.s:M.'=none'
-exe 'hi WildMenu     '.s:M.'bg='.s:YELLOW.' '.s:M.'fg='.s:BG .' '.s:M.'=none'
+exe 'hi MatchParen     '.s:M.'bg='.s:RED   .' '.s:M.'fg='.s:BG    .' '.s:M.'=none'
+exe 'hi Error          '.s:M.'bg='.s:RED   .' '.s:M.'fg='.s:BG    .' '.s:M.'=none'
 
-exe 'hi DiffAdd      '.s:M.'bg='.s:BLUE .' '.s:M.'fg='.s:GREY0.' '.s:M.'=none'
-exe 'hi DiffChange   '.s:M.'bg='.s:GREEN.' '.s:M.'fg='.s:GREY0.' '.s:M.'=none'
-exe 'hi DiffDelete   '.s:M.'bg='.s:RED  .' '.s:M.'fg='.s:GREY0.' '.s:M.'=none'
-exe 'hi DiffText     '.s:M.'bg='.s:GREY1.' '.s:M.'fg='.'NONE'.'  '.s:M.'=none'
+exe 'hi Type           '.s:M.'fg='.s:YELLOW.' '.s:M.'=bold'
+exe 'hi StorageClass   '.s:M.'fg='.s:YELLOW.' '.s:M.'=bold'
+exe 'hi Structure      '.s:M.'fg='.s:YELLOW.' '.s:M.'=bold'
+exe 'hi Todo           '.s:M.'bg='.s:YELLOW.' '.s:M.'fg='.s:BG    .' '.s:M.'=none'
+exe 'hi WildMenu       '.s:M.'bg='.s:YELLOW.' '.s:M.'fg='.s:BG    .' '.s:M.'=none'
+
+exe 'hi DiffAdd        '.s:M.'bg='.s:BLUE  .' '.s:M.'fg='.s:GREY0 .' '.s:M.'=none'
+exe 'hi DiffChange     '.s:M.'bg='.s:GREEN .' '.s:M.'fg='.s:GREY0 .' '.s:M.'=none'
+exe 'hi DiffDelete     '.s:M.'bg='.s:RED   .' '.s:M.'fg='.s:GREY0 .' '.s:M.'=none'
+exe 'hi DiffText       '.s:M.'bg='.s:GREY1 .' '.s:M.'fg='.'NONE'  .' '.s:M.'=none'
 
 
 " Colors for the User Interface.
-exe 'hi Cursor       '.s:M.'bg='.s:GREY1.' '.s:M.'fg='.s:BG   .' '.s:M.'=bold'
-exe 'hi Search       '.s:M.'bg='.s:YELLOW.' '.s:M.'fg='.s:BG  .' '.s:M.'=none'
-exe 'hi IncSearch    '.s:M.'bg='.s:YELLOW.' '.s:M.'fg='.s:BG  .' '.s:M.'=none'
-exe 'hi ColorColumn  '.s:M.'bg='.s:GREY2.' '.s:M.'fg='.'NONE' .' '.s:M.'=none'
-exe 'hi SignColumn   '.s:M.'bg='.s:GREY2.' '.s:M.'fg='.s:YELLOW.' '.s:M.'=none'
+exe 'hi Cursor         '.s:M.'bg='.s:GREY1 .' '.s:M.'fg='.s:BG    .' '.s:M.'=bold'
+exe 'hi Search         '.s:M.'bg='.s:YELLOW.' '.s:M.'fg='.s:BG    .' '.s:M.'=none'
+exe 'hi IncSearch      '.s:M.'bg='.s:YELLOW.' '.s:M.'fg='.s:BG    .' '.s:M.'=none'
+exe 'hi ColorColumn    '.s:M.'bg='.s:GREY2 .' '.s:M.'fg='.'NONE'  .' '.s:M.'=none'
+exe 'hi SignColumn     '.s:M.'bg='.s:GREY2 .' '.s:M.'fg='.s:YELLOW.' '.s:M.'=none'
 
-exe 'hi WarningMsg   '.s:M.'bg='.s:BG   .' '.s:M.'fg='.s:RED  .' '.s:M.'=bold'
-exe 'hi ErrorMsg     '.s:M.'bg='.s:BG   .' '.s:M.'fg='.s:RED  .' '.s:M.'=bold'
-exe 'hi ModeMsg      '.s:M.'bg='.s:BG   .' '.s:M.'fg='.s:BLUE .' '.s:M.'=bold'
-exe 'hi MoreMsg      '.s:M.'bg='.s:BG   .' '.s:M.'fg='.s:BLUE .' '.s:M.'=bold'
-exe 'hi Question     '.s:M.'bg='.s:BG   .' '.s:M.'fg='.s:BLUE .' '.s:M.'=bold'
-exe 'hi Directory    '.s:M.'bg='.s:BG   .' '.s:M.'fg='.s:GREEN.' '.s:M.'=none'
-exe 'hi SpecialKey   '.s:M.'bg='.s:BG   .' '.s:M.'fg='.s:GREY0.' '.s:M.'=none'
-exe 'hi Titled       '.s:M.'bg='.s:BG   .' '.s:M.'fg='.s:GREY0.' '.s:M.'=none'
-exe 'hi NonText      '.s:M.'bg='.s:BG   .' '.s:M.'fg='.s:GREY1.' '.s:M.'=bold'
-exe 'hi CursorLineNr '.s:M.'bg='.s:BG   .' '.s:M.'fg='.s:GREY1.' '.s:M.'=bold'
+exe 'hi WarningMsg     '.s:M.'bg='.s:BG    .' '.s:M.'fg='.s:RED   .' '.s:M.'=bold'
+exe 'hi ErrorMsg       '.s:M.'bg='.s:BG    .' '.s:M.'fg='.s:RED   .' '.s:M.'=bold'
+exe 'hi ModeMsg        '.s:M.'bg='.s:BG    .' '.s:M.'fg='.s:BLUE  .' '.s:M.'=bold'
+exe 'hi MoreMsg        '.s:M.'bg='.s:BG    .' '.s:M.'fg='.s:BLUE  .' '.s:M.'=bold'
+exe 'hi Question       '.s:M.'bg='.s:BG    .' '.s:M.'fg='.s:BLUE  .' '.s:M.'=bold'
+exe 'hi Directory      '.s:M.'bg='.s:BG    .' '.s:M.'fg='.s:GREEN .' '.s:M.'=none'
+exe 'hi SpecialKey     '.s:M.'bg='.s:BG    .' '.s:M.'fg='.s:GREY0 .' '.s:M.'=none'
+exe 'hi Titled         '.s:M.'bg='.s:BG    .' '.s:M.'fg='.s:GREY0 .' '.s:M.'=none'
+exe 'hi CursorLineNr   '.s:M.'bg='.s:BG    .' '.s:M.'fg='.s:GREY1 .' '.s:M.'=bold'
 
-exe 'hi PmenuSel     '.s:M.'bg='.s:BLUE .' '.s:M.'fg='.s:GREY0.' '.s:M.'=none'
-exe 'hi PmenuSBar    '.s:M.'bg='.s:GREY2.' '.s:M.'fg='.s:GREY0.' '.s:M.'=none'
-exe 'hi PmenuThumb   '.s:M.'bg='.s:GREY0.' '.s:M.'fg='.s:BG   .' '.s:M.'=none'
+exe 'hi PmenuSel       '.s:M.'bg='.s:BLUE  .' '.s:M.'fg='.s:GREY0 .' '.s:M.'=none'
+exe 'hi PmenuSBar      '.s:M.'bg='.s:GREY2 .' '.s:M.'fg='.s:GREY0 .' '.s:M.'=none'
+exe 'hi PmenuThumb     '.s:M.'bg='.s:GREY0 .' '.s:M.'fg='.s:BG    .' '.s:M.'=none'
 
 if (has('gui_running') || &t_Co == 256)
-  exe 'hi Visual       '.s:M.'bg='.s:GREY2.' '.s:M.'fg='.'NONE' .' '.s:M.'=none'
-  exe 'hi Pmenu        '.s:M.'bg='.s:GREY2.' '.s:M.'fg='.s:GREY0.' '.s:M.'=none'
-  exe 'hi Linenr       '.s:M.'bg='.s:GREY2.' '.s:M.'fg='.s:GREY1.' '.s:M.'=none'
-  exe 'hi VertSplit    '.s:M.'bg='.s:GREY1.' '.s:M.'fg='.s:GREY2.' '.s:M.'=none'
-  exe 'hi StatusLine   '.s:M.'bg='.s:GREY1.' '.s:M.'fg='.s:GREY2.' '.s:M.'=bold'
-  exe 'hi StatusLineNC '.s:M.'bg='.s:GREY2.' '.s:M.'fg='.s:GREY1.' '.s:M.'=none'
-  exe 'hi Folded       '.s:M.'bg='.s:GREY2.' '.s:M.'fg='.s:GREY1.' '.s:M.'=none'
-  exe 'hi FoldColumn   '.s:M.'bg='.s:GREY2.' '.s:M.'fg='.s:GREY1.' '.s:M.'=none'
+  exe 'hi Visual       '.s:M.'bg='.s:GREY2 .' '.s:M.'fg='.'NONE'  .' '.s:M.'=none'
+  exe 'hi Pmenu        '.s:M.'bg='.s:GREY2 .' '.s:M.'fg='.s:GREY0 .' '.s:M.'=none'
+  exe 'hi Linenr       '.s:M.'bg='.s:GREY2 .' '.s:M.'fg='.s:GREY1 .' '.s:M.'=none'
+  exe 'hi VertSplit    '.s:M.'bg='.s:GREY1 .' '.s:M.'fg='.s:GREY2 .' '.s:M.'=none'
+  exe 'hi StatusLine   '.s:M.'bg='.s:GREY1 .' '.s:M.'fg='.s:GREY2 .' '.s:M.'=bold'
+  exe 'hi StatusLineNC '.s:M.'bg='.s:GREY2 .' '.s:M.'fg='.s:GREY1 .' '.s:M.'=none'
+  exe 'hi Folded       '.s:M.'bg='.s:GREY2 .' '.s:M.'fg='.s:GREY1 .' '.s:M.'=none'
+  exe 'hi FoldColumn   '.s:M.'bg='.s:GREY2 .' '.s:M.'fg='.s:GREY1 .' '.s:M.'=none'
 else
   "Eight-color console Vim only supports one shade of grey, so when the FG and
   "BG should both be shades of grey, console Vim must do it differently.
@@ -186,12 +193,12 @@ else
     let s:GREYX = s:GREY1
     let s:GREYY = s:BLACK
   endif
-  exe 'hi Visual       '.s:M.'bg='.s:GREYY.' '.s:M.'fg='.'NONE' .' '.s:M.'=none'
-  exe 'hi Pmenu        '.s:M.'bg='.s:GREYY.' '.s:M.'fg='.s:GREYX.' '.s:M.'=none'
-  exe 'hi Linenr       '.s:M.'bg='.s:GREYX.' '.s:M.'fg='.s:GREYY.' '.s:M.'=none'
-  exe 'hi VertSplit    '.s:M.'bg='.s:GREYX.' '.s:M.'fg='.s:GREYY.' '.s:M.'=none'
-  exe 'hi StatusLine   '.s:M.'bg='.s:GREYY.' '.s:M.'fg='.s:GREYX.' '.s:M.'=bold'
-  exe 'hi StatusLineNC '.s:M.'bg='.s:GREYX.' '.s:M.'fg='.s:GREYY.' '.s:M.'=none'
-  exe 'hi Folded       '.s:M.'bg='.s:GREYX.' '.s:M.'fg='.s:GREYY.' '.s:M.'=none'
-  exe 'hi FoldColumn   '.s:M.'bg='.s:GREYX.' '.s:M.'fg='.s:GREYY.' '.s:M.'=none'
+  exe 'hi Visual       '.s:M.'bg='.s:GREYY .' '.s:M.'fg='.'NONE'  .' '.s:M.'=none'
+  exe 'hi Pmenu        '.s:M.'bg='.s:GREYY .' '.s:M.'fg='.s:GREYX .' '.s:M.'=none'
+  exe 'hi Linenr       '.s:M.'bg='.s:GREYX .' '.s:M.'fg='.s:GREYY .' '.s:M.'=none'
+  exe 'hi VertSplit    '.s:M.'bg='.s:GREYX .' '.s:M.'fg='.s:GREYY .' '.s:M.'=none'
+  exe 'hi StatusLine   '.s:M.'bg='.s:GREYY .' '.s:M.'fg='.s:GREYX .' '.s:M.'=bold'
+  exe 'hi StatusLineNC '.s:M.'bg='.s:GREYX .' '.s:M.'fg='.s:GREYY .' '.s:M.'=none'
+  exe 'hi Folded       '.s:M.'bg='.s:GREYX .' '.s:M.'fg='.s:GREYY .' '.s:M.'=none'
+  exe 'hi FoldColumn   '.s:M.'bg='.s:GREYX .' '.s:M.'fg='.s:GREYY .' '.s:M.'=none'
 endif

--- a/doc/colorscheme-primary.txt
+++ b/doc/colorscheme-primary.txt
@@ -42,6 +42,10 @@ does not support 256 colors. No problem - just remove that line and consult
 If you want to disable italic font, add this line to your .vimrc: >
   let g:colorscheme_primary_disable_italic = 1
 <
+                                        *g:colorscheme_primary_enable_transparent_bg*
+If you want to enable background transparency, add this line to your .vimrc: >
+  let g:colorscheme_primary_enable_transparent_bg = 1
+<
 
 ==============================================================================
 OPTIONS                                          *colorscheme-primary-options*


### PR DESCRIPTION
Fixes #10

Option: `let g:colorscheme_primary_bg_transparency = 1`

Before:
![dark background](https://github.com/windvalley/bigfiles/blob/main/vim-colorscheme-primary/dark_bg.png?raw=true)

After:
![dark background transparency](https://github.com/windvalley/bigfiles/blob/main/vim-colorscheme-primary/dark_bg_transparency.png?raw=true)