### PR TITLE
Check &termguicolors to decide whether to enable truecolor.

### DIFF
--- a/colors/primary.vim
+++ b/colors/primary.vim
@@ -27,7 +27,7 @@ let g:colors_name = 'primary'
 let s:disable_italic = get(g:,'colorscheme_primary_disable_italic', 0)
 let s:enable_transparent_bg = get(g:,'colorscheme_primary_enable_transparent_bg', 0)
 
-if has('gui_running') || has('termguicolors')  "Graphical Vim
+if has('gui_running') || (has('termguicolors') && &termguicolors)  "Graphical Vim
   "Set color palette with RGB colors
   let s:RED    = '#EA4335'
   let s:GREEN  = '#34A853'


### PR DESCRIPTION
This fixes a regression from 5a5e05a: the termguicolors feature is available when the version of Vim is _built_ with truecolor support (i.e. `+termguicolors`), but this doesn't necessarily mean that that support is being used: the `&termguicolors` option controls that.